### PR TITLE
Changed the candlestick format from LHOC to OHLC

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -6,7 +6,7 @@ class Candle:
     UP_MOVE = 1
     DOWN_MOVE = -1
 
-    def __init__(self, min_value: float, max_value: float, begin_value: float, end_value: float):
+    def __init__(self, begin_value: float, max_value: float, min_value: float, end_value: float):
         self.min_value = float(min_value)
         self.max_value = float(max_value)
         self.begin_value = float(begin_value)

--- a/test_graph.py
+++ b/test_graph.py
@@ -3,7 +3,7 @@ from graph import CandleStickGraph, Candle
 
 class BloomfilterTest(TestCase):
     def test_candle_int_4(self):
-        c = Candle(0, 4, 1, 3)
+        c = Candle(1, 4, 0, 3)
         g = CandleStickGraph([c], 4)
         drawn_string = g.draw(False)
 
@@ -16,7 +16,7 @@ class BloomfilterTest(TestCase):
         self.assertEquals(CandleStickGraph.SYMBOL_STICK, first_candle[3])
 
     def test_candle_frac_8(self):
-        c = Candle(0, 4, 1.5, 3.5)
+        c = Candle(1.5, 4, 0, 3.5)
         g = CandleStickGraph([c], 8)
         drawn_string = g.draw(False)
 
@@ -32,7 +32,7 @@ class BloomfilterTest(TestCase):
         self.assertEquals(CandleStickGraph.SYMBOL_STICK, first_candle[7])
 
     def test_candle_half_1(self):
-        c = Candle(0, 4, 1.5, 3.5)
+        c = Candle(1.5, 4, 0, 3.5)
         g = CandleStickGraph([c], 4)
         drawn_string = g.draw(False)
 
@@ -44,7 +44,7 @@ class BloomfilterTest(TestCase):
         self.assertEquals(CandleStickGraph.SYMBOL_STICK, first_candle[3])
 
     def test_candle_half_2(self):
-        c = Candle(1.3, 4, 1.5, 3.7)
+        c = Candle(1.5, 4, 1.3, 3.7)
         c_fake = Candle(0, 4, 0, 0)
         g = CandleStickGraph([c, c_fake], 4)
         drawn_string = g.draw(False)
@@ -57,7 +57,7 @@ class BloomfilterTest(TestCase):
         self.assertEquals(CandleStickGraph.SYMBOL_NOTHING, first_candle[3])
 
     def test_candle_half_3(self):
-        c = Candle(1.2, 4, 1.5, 3.8)
+        c = Candle(1.5, 4, 1.2, 3.8)
         c_fake = Candle(0, 4, 0, 0)
         g = CandleStickGraph([c, c_fake], 4)
         drawn_string = g.draw(False)


### PR DESCRIPTION
I know this is a tiny, one-line change barely worth creating a PR for, but since the standard is OHLC I feel this greatly improves workability.